### PR TITLE
Motor speeds synchronizer/sanitizer

### DIFF
--- a/config/px4_api.yaml
+++ b/config/px4_api.yaml
@@ -8,6 +8,10 @@ simulated_rtk:
   utm_y: 5249465.43086
   amsl: 340.0
 
+motor_speeds:
+  num_motors: 4
+  motor_slowdown_constant: 0.0159236 # used only in simualation
+
 inputs:
   control_group: false
   attitude_rate: true

--- a/launch/api.launch
+++ b/launch/api.launch
@@ -34,6 +34,7 @@
       <param name="topic_prefix" type="string" value="/$(arg UAV_NAME)/" />
       <param name="uav_name" type="string" value="$(arg UAV_NAME)" />
       <param name="simulation" type="bool" value="$(eval arg('RUN_TYPE') == 'simulation')" />
+      <param name="motor_speeds/topic_wo_num" type="string" value="motor_speed/" />
 
       <remap if="$(eval arg('RUN_TYPE') == 'simulation')" from="~ground_truth_in" to="ground_truth" />
       <remap if="$(eval arg('RUN_TYPE') == 'realworld')" from="~rtk_in" to="rtk/bestpos" />
@@ -48,10 +49,12 @@
       <remap from="~mavros_rc_in" to="mavros/rc/in" />
       <remap from="~mavros_altitude_in" to="mavros/altitude" />
       <remap from="~mavros_battery_in" to="mavros/battery" />
+      <remap from="~mavros_esc_status_in" to="mavros/esc_status" />
       <remap from="~mavros_cmd_out" to="mavros/cmd/command" />
       <remap from="~mavros_set_mode_out" to="mavros/set_mode" />
       <remap from="~mavros_attitude_setpoint_out" to="mavros/setpoint_raw/attitude" />
       <remap from="~mavros_actuator_control_out" to="mavros/actuator_control" />
+      <remap from="~motor_speed_sync_out" to="motor_speeds_sync" />
 
     </node>
 


### PR DESCRIPTION
Subscribes motor speeds in both simulation and realworld uav. @parakhm95 does it make sense like this for you? This will allow us to have the same topic for both simulation and uav.

**Simulation**
* Individual motor speeds published from gazebo plugin on separate topics `/uav1/motor_speed/X` of type `std_msgs/Float64`.
* Subscribes separate motor speed topics and publishes most recent data on a merged topic `/uav1/motor_speeds_sync` of type `mrs_mgs/Float64ArrayStamped` every time any of the separate motor speed messages arrives.
* Timestamp is the same as the latest separate motor speed message received.

**Realworld**
* Subscribes `/uav1/mavros/esc_status` topic of type `mavros_msgs/ESCStatus`.
* The message contains speeds of all motors with separate timestamps but sometimes the motor speed value is 0, which is pretty bad for state estimation. 
* The 0 values are filtered out and the previous valid measurement is used instead.
* Publishes most recent data on a merged topic `/uav1/motor_speeds_sync` of type `mrs_mgs/Float64ArrayStamped` every time any of the separate motor speed messages arrives.
* Timestamp is the average of all timestamps in the subscribed message.