### PR TITLE
Use local_position/odom as the main odometry source

### DIFF
--- a/launch/api.launch
+++ b/launch/api.launch
@@ -43,8 +43,7 @@
       <remap if="$(eval arg('RUN_TYPE') == 'simulation')" from="~ground_truth_in" to="ground_truth" />
       <remap if="$(eval arg('RUN_TYPE') == 'realworld')" from="~rtk_in" to="rtk/bestpos" />
       <remap from="~mavros_state_in" to="mavros/state" />
-      <remap if="$(eval arg('OLD_PX4_FW') == 0)" from="~mavros_local_position_in" to="mavros/odometry/in" />
-      <remap if="$(eval arg('OLD_PX4_FW') == 1)" from="~mavros_local_position_in" to="mavros/local_position/odom" />
+      <remap from="~mavros_local_position_in" to="mavros/local_position/odom" />
       <remap from="~mavros_global_position_in" to="mavros/global_position/global" />
       <remap from="~mavros_garmin_in" to="mavros/distance_sensor/garmin" />
       <remap from="~mavros_imu_in" to="mavros/imu/data" />

--- a/launch/api.launch
+++ b/launch/api.launch
@@ -44,6 +44,7 @@
       <remap if="$(eval arg('RUN_TYPE') == 'realworld')" from="~rtk_in" to="rtk/bestpos" />
       <remap from="~mavros_state_in" to="mavros/state" />
       <remap from="~mavros_local_position_in" to="mavros/local_position/odom" />
+      <remap from="~mavros_odometry_in" to="mavros/odometry/in" />
       <remap from="~mavros_global_position_in" to="mavros/global_position/global" />
       <remap from="~mavros_garmin_in" to="mavros/distance_sensor/garmin" />
       <remap from="~mavros_imu_in" to="mavros/imu/data" />

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -123,6 +123,9 @@ private:
   mrs_lib::SubscribeHandler<nav_msgs::Odometry> sh_mavros_odometry_local_;
   void                                          callbackOdometryLocal(const nav_msgs::Odometry::ConstPtr msg);
 
+  mrs_lib::SubscribeHandler<nav_msgs::Odometry> sh_mavros_odometry_in_;
+  void                                          callbackOdometryIn(const nav_msgs::Odometry::ConstPtr msg);
+
   mrs_lib::SubscribeHandler<sensor_msgs::NavSatFix> sh_mavros_gps_;
   void                                              callbackNavsatFix(const sensor_msgs::NavSatFix::ConstPtr msg);
 
@@ -251,6 +254,8 @@ void MrsUavPx4Api::initialize(const ros::NodeHandle& parent_nh, std::shared_ptr<
                                                                    &MrsUavPx4Api::callbackMavrosState, this);
 
   sh_mavros_odometry_local_ = mrs_lib::SubscribeHandler<nav_msgs::Odometry>(shopts, "mavros_local_position_in", &MrsUavPx4Api::callbackOdometryLocal, this);
+
+  sh_mavros_odometry_in_ = mrs_lib::SubscribeHandler<nav_msgs::Odometry>(shopts, "mavros_odometry_in", &MrsUavPx4Api::callbackOdometryIn, this);
 
   sh_mavros_gps_ = mrs_lib::SubscribeHandler<sensor_msgs::NavSatFix>(shopts, "mavros_global_position_in", &MrsUavPx4Api::callbackNavsatFix, this);
 
@@ -670,6 +675,48 @@ void MrsUavPx4Api::callbackMavrosState(const mavros_msgs::State::ConstPtr msg) {
 
 //}
 
+/* callbackOdometryIn() //{ */
+
+void MrsUavPx4Api::callbackOdometryIn(const nav_msgs::Odometry::ConstPtr msg) {
+
+  if (!is_initialized_) {
+    return;
+  }
+
+  ROS_INFO_ONCE("[MrsUavPx4Api]: getting Mavros's odometry in");
+
+  auto odom = msg;
+
+  // | ------------------- publish orientation ------------------ |
+
+  if (_capabilities_.produces_orientation) {
+
+    geometry_msgs::QuaternionStamped orientation;
+
+    orientation.header.stamp    = odom->header.stamp;
+    orientation.header.frame_id = _uav_name_ + "/" + _world_frame_name_;
+    orientation.quaternion      = odom->pose.pose.orientation;
+
+    common_handlers_->publishers.publishOrientation(orientation);
+  }
+
+  // | ---------------- publish angular velocity ---------------- |
+
+  if (_capabilities_.produces_angular_velocity) {
+
+    geometry_msgs::Vector3Stamped angular_velocity;
+
+    angular_velocity.header.stamp    = odom->header.stamp;
+    angular_velocity.header.frame_id = _uav_name_ + "/" + _body_frame_name_;
+    angular_velocity.vector          = odom->twist.twist.angular;
+
+    common_handlers_->publishers.publishAngularVelocity(angular_velocity);
+  }
+
+}
+
+//}
+
 /* callbackOdometryLocal() //{ */
 
 void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::Odometry::ConstPtr msg) {
@@ -695,19 +742,6 @@ void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::Odometry::ConstPtr msg)
     common_handlers_->publishers.publishPosition(position);
   }
 
-  // | ------------------- publish orientation ------------------ |
-
-  if (_capabilities_.produces_orientation) {
-
-    geometry_msgs::QuaternionStamped orientation;
-
-    orientation.header.stamp    = odom->header.stamp;
-    orientation.header.frame_id = _uav_name_ + "/" + _world_frame_name_;
-    orientation.quaternion      = odom->pose.pose.orientation;
-
-    common_handlers_->publishers.publishOrientation(orientation);
-  }
-
   // | -------------------- publish velocity -------------------- |
 
   if (_capabilities_.produces_velocity) {
@@ -719,19 +753,6 @@ void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::Odometry::ConstPtr msg)
     velocity.vector          = odom->twist.twist.linear;
 
     common_handlers_->publishers.publishVelocity(velocity);
-  }
-
-  // | ---------------- publish angular velocity ---------------- |
-
-  if (_capabilities_.produces_angular_velocity) {
-
-    geometry_msgs::Vector3Stamped angular_velocity;
-
-    angular_velocity.header.stamp    = odom->header.stamp;
-    angular_velocity.header.frame_id = _uav_name_ + "/" + _body_frame_name_;
-    angular_velocity.vector          = odom->twist.twist.angular;
-
-    common_handlers_->publishers.publishAngularVelocity(angular_velocity);
   }
 
   // | -------------------- publish odometry -------------------- |


### PR DESCRIPTION
This PR is required for PR https://github.com/ctu-mrs/mrs_uav_state_estimators/pull/4 . 

The main odometry source becomes `mavros/local_position/odom`. The topic `mavros/odometry/in` has incorrect velocities and is very dangerous to use with the F9P  estimator.

However, `mavros/local_position/odom` is not published when GPS is not present on the UAV, so for non-GNSS estimators this topic cannot be used but orientation is still needed. 

I propose that hw_api publishes the orientation from the `odometry/in` topic, which is always present, and the `local_position/odom` is kept as `hw_api/odometry`. This needs to be done before the merge to be able to use the F9P estimator and the non-GNSS estimators without error-prone remapping of hw_api input odometry topic for each use case.