### PR TITLE
Reprojection of PX4 odometry from AZE to UTM

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -40,6 +40,8 @@
 #define PWM_MAX 2000
 #define PWM_DEADBAND 200
 #define PWM_RANGE PWM_MAX - PWM_MIN
+#define RAD2DEG(x) ((x) * 180.0 / M_PI)
+#define DEG2RAD(x) ((x) * M_PI / 180.0)
 
 //}
 
@@ -121,6 +123,14 @@ private:
   double      _sim_rtk_utm_y_;
   std::string _sim_rtk_utm_zone_;
   double      _sim_rtk_amsl_;
+
+  double _ref_sin_lat;
+  double _ref_cos_lat;
+  double _ref_lat;
+  double _ref_lon;
+  double _ref_utm_x;
+  double _ref_utm_y;
+  bool _ref_latlon_init = false;
 
   // | --------------------- service clients -------------------- |
 
@@ -760,13 +770,54 @@ void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::msg::Odometry::ConstSha
 
   // | -------------------- publish position -------------------- |
 
+  geometry_msgs::msg::PointStamped position;
+
+  position.header.stamp    = odom->header.stamp;
+  position.header.frame_id = _uav_name_ + "/" + _world_frame_name_;
+  position.point           = odom->pose.pose.position;
+
+  double lat, lon, correct_x, correct_y;
+
   if (_capabilities_.produces_position) {
 
-    geometry_msgs::msg::PointStamped position;
+    if (_capabilities_.produces_gnss and _ref_latlon_init) {
 
-    position.header.stamp    = odom->header.stamp;
-    position.header.frame_id = _uav_name_ + "/" + _world_frame_name_;
-    position.point           = odom->pose.pose.position;
+      // The px4 Azimuthal Equidistant Projection of WGS84 is inconsistent with the UTM conversion is MRS system,
+      // therefore, we convert it back to WGS84 frame and then convert correctly using mrs_lib.
+
+      // BEGIN PX4 CODE
+      const double x_rad = (double)odom->pose.pose.position.y / 6371000.0;
+      const double y_rad = (double)odom->pose.pose.position.x / 6371000.0;
+      const double c = sqrt(x_rad * x_rad + y_rad * y_rad);
+
+      if (fabs(c) > 0) {
+        const double sin_c = sin(c);
+        const double cos_c = cos(c);
+
+        const double lat_rad = asin(cos_c * _ref_sin_lat + (x_rad * sin_c * _ref_cos_lat) / c);
+        const double lon_rad = (_ref_lon + atan2(y_rad * sin_c, c * _ref_cos_lat * cos_c - x_rad * _ref_sin_lat * sin_c));
+
+        lat = RAD2DEG(lat_rad);
+        lon = RAD2DEG(lon_rad);
+
+      } else {
+        lat = RAD2DEG(_ref_lat);
+        lon = RAD2DEG(_ref_lon);
+      }
+      // END PX4 CODE
+
+      mrs_lib::UTM(lat, lon, &correct_x, &correct_y);
+
+      correct_x = correct_x - _ref_utm_x;
+      correct_y = correct_y - _ref_utm_y;
+
+      position.point.x = correct_x;
+      position.point.y = correct_y;
+
+      RCLCPP_DEBUG(node_->get_logger(), "position_px4_x: %f, position_px4_y: %f", position.point.x, position.point.y);
+      RCLCPP_DEBUG(node_->get_logger(), "correct_mrs_x: %f, correct_mrs_y: %f", correct_x, correct_y);
+
+    }
 
     common_handlers_->publishers.publishPosition(position);
   }
@@ -787,7 +838,18 @@ void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::msg::Odometry::ConstSha
   // | -------------------- publish odometry -------------------- |
 
   if (_capabilities_.produces_odometry) {
-    common_handlers_->publishers.publishOdometry(*odom);
+
+    if (_capabilities_.produces_gnss and _ref_latlon_init) {
+
+      auto odom_new = *odom;
+      odom_new.pose.pose.position.x = correct_x;
+      odom_new.pose.pose.position.y = correct_y;
+      common_handlers_->publishers.publishOdometry(odom_new);
+
+    } else {
+
+      common_handlers_->publishers.publishOdometry(*odom);
+    }
   }
 }
 
@@ -848,6 +910,17 @@ void MrsUavPx4Api::callbackNavsatFix(const sensor_msgs::msg::NavSatFix::ConstSha
   if (_capabilities_.produces_gnss) {
 
     common_handlers_->publishers.publishGNSS(*msg);
+
+    if (!_ref_latlon_init) {
+
+      _ref_lat     = DEG2RAD(msg->latitude);
+      _ref_lon     = DEG2RAD(msg->longitude);
+      _ref_sin_lat = sin(_ref_lat);
+      _ref_cos_lat = cos(_ref_lat);
+      mrs_lib::UTM(msg->latitude, msg->longitude, &_ref_utm_x, &_ref_utm_y);
+      _ref_latlon_init = true;
+    }
+
   }
 }
 


### PR DESCRIPTION
Replicating #3 into the `ros2` branch, the only notable difference is that I had to

```cpp
#define RAD2DEG(x) ((x) * 180.0 / M_PI)
#define DEG2RAD(x) ((x) * M_PI / 180.0)
```