### PR TITLE
fix: orientation and angular velocity in published odometry

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -107,7 +107,7 @@ private:
   double _ref_lon;
   double _ref_utm_x;
   double _ref_utm_y;
-  bool _ref_latlon_init = false;
+  bool   _ref_latlon_init = false;
 
   // | --------------------- service clients -------------------- |
 
@@ -173,6 +173,12 @@ private:
   std::atomic<bool> armed_     = false;
   std::atomic<bool> connected_ = false;
   std::mutex        mutex_status_;
+
+  geometry_msgs::Quaternion orientation_;
+  std::mutex                mutex_orientation_;
+
+  geometry_msgs::Vector3 angular_velocity_;
+  std::mutex             mutex_angular_velocity_;
 };
 
 //}
@@ -695,6 +701,15 @@ void MrsUavPx4Api::callbackOdometryIn(const nav_msgs::Odometry::ConstPtr msg) {
 
   auto odom = msg;
 
+  {
+    std::scoped_lock lock(mutex_orientation_);
+    orientation_ = odom->pose.pose.orientation;
+  }
+  {
+    std::scoped_lock lock(mutex_angular_velocity_);
+    angular_velocity_ = odom->twist.twist.angular;
+  }
+
   // | ------------------- publish orientation ------------------ |
 
   if (_capabilities_.produces_orientation) {
@@ -720,7 +735,6 @@ void MrsUavPx4Api::callbackOdometryIn(const nav_msgs::Odometry::ConstPtr msg) {
 
     common_handlers_->publishers.publishAngularVelocity(angular_velocity);
   }
-
 }
 
 //}
@@ -735,29 +749,38 @@ void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::Odometry::ConstPtr msg)
 
   ROS_INFO_ONCE("[MrsUavPx4Api]: getting Mavros's local odometry");
 
-  auto odom = msg;
+  nav_msgs::Odometry odom = *msg;
+
+  {
+    std::scoped_lock lock(mutex_orientation_);
+    odom.pose.pose.orientation = orientation_ ;
+  }
+  {
+    std::scoped_lock lock(mutex_angular_velocity_);
+    odom.twist.twist.angular = angular_velocity_ ;
+  }
 
   // | -------------------- publish position -------------------- |
 
   geometry_msgs::PointStamped position;
 
-  position.header.stamp    = odom->header.stamp;
+  position.header.stamp    = msg->header.stamp;
   position.header.frame_id = _uav_name_ + "/" + _world_frame_name_;
-  position.point           = odom->pose.pose.position;
+  position.point           = msg->pose.pose.position;
 
   double lat, lon, correct_x, correct_y;
 
   if (_capabilities_.produces_position) {
-    
+
     if (_capabilities_.produces_gnss and _ref_latlon_init) {
 
       // The px4 Azimuthal Equidistant Projection of WGS84 is inconsistent with the UTM conversion is MRS system,
       // therefore, we convert it back to WGS84 frame and then convert correctly using mrs_lib.
-      
+
       // BEGIN PX4 CODE
-      const double x_rad = (double)odom->pose.pose.position.y / 6371000.0;
-      const double y_rad = (double)odom->pose.pose.position.x / 6371000.0;
-      const double c = sqrt(x_rad * x_rad + y_rad * y_rad);
+      const double x_rad = (double)msg->pose.pose.position.y / 6371000.0;
+      const double y_rad = (double)msg->pose.pose.position.x / 6371000.0;
+      const double c     = sqrt(x_rad * x_rad + y_rad * y_rad);
 
       if (fabs(c) > 0) {
         const double sin_c = sin(c);
@@ -785,7 +808,6 @@ void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::Odometry::ConstPtr msg)
 
       ROS_DEBUG("[MrsUavPx4Api]: position_px4_x: %f, position_px4_y: %f", position.point.x, position.point.y);
       ROS_DEBUG("[MrsUavPx4Api]: correct_mrs_x: %f, correct_mrs_y: %f", correct_x, correct_y);
-
     }
 
     common_handlers_->publishers.publishPosition(position);
@@ -797,9 +819,9 @@ void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::Odometry::ConstPtr msg)
 
     geometry_msgs::Vector3Stamped velocity;
 
-    velocity.header.stamp    = odom->header.stamp;
+    velocity.header.stamp    = msg->header.stamp;
     velocity.header.frame_id = _uav_name_ + "/" + _body_frame_name_;
-    velocity.vector          = odom->twist.twist.linear;
+    velocity.vector          = msg->twist.twist.linear;
 
     common_handlers_->publishers.publishVelocity(velocity);
   }
@@ -810,14 +832,14 @@ void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::Odometry::ConstPtr msg)
 
     if (_capabilities_.produces_gnss and _ref_latlon_init) {
 
-      auto odom_new = *odom;
+      auto odom_new                 = odom;
       odom_new.pose.pose.position.x = correct_x;
       odom_new.pose.pose.position.y = correct_y;
       common_handlers_->publishers.publishOdometry(odom_new);
 
     } else {
 
-      common_handlers_->publishers.publishOdometry(*odom);
+      common_handlers_->publishers.publishOdometry(odom);
     }
   }
 }
@@ -847,7 +869,6 @@ void MrsUavPx4Api::callbackNavsatFix(const sensor_msgs::NavSatFix::ConstPtr msg)
       mrs_lib::UTM(msg->latitude, msg->longitude, &_ref_utm_x, &_ref_utm_y);
       _ref_latlon_init = true;
     }
-
   }
 }
 
@@ -996,8 +1017,8 @@ void MrsUavPx4Api::callbackGpsStatusRaw(const mavros_msgs::GPSRAW::ConstPtr msg)
 
     mrs_msgs::GpsInfo gps_info_out;
 
-    gps_info_out.stamp = msg->header.stamp;  // [GPS_FIX_TYPE] GPS fix type
-    gps_info_out.fix_type = msg->fix_type;  // [GPS_FIX_TYPE] GPS fix type
+    gps_info_out.stamp    = msg->header.stamp;  // [GPS_FIX_TYPE] GPS fix type
+    gps_info_out.fix_type = msg->fix_type;      // [GPS_FIX_TYPE] GPS fix type
 
     gps_info_out.lat                = double(msg->lat) / 10000000;  // [deg] Latitude (WGS84, EGM96 ellipsoid)
     gps_info_out.lon                = double(msg->lon) / 10000000;  // [deg] Longitude (WGS84, EGM96 ellipsoid)


### PR DESCRIPTION
# Issue overview

Once again, we must revisit the `mavros/odometry/in` and `mavros/local_position/odom` disparity. The current setup should work fine for all estimators except `f9p`, which has a pretty serious issue with orientation and angular velocities. Essentially, even when the `hw_api/odometry` is published at 100 Hz, the orientation and angular velocity is updated only at 10 Hz so it is publishing the same value 10 times (i.e. zero-order interpolation). This can have a serious impact on flight performance.

<img width="1928" height="1256" alt="Screenshot from 2026-03-10 14-56-53" src="https://github.com/user-attachments/assets/601c37bf-85af-4a30-b367-9caa7d71c627" />

# Discussion

**First, why only `f9p` estimator has this issue?**

The `f9p` estimator is essentially a passthrough estimator with only slight processing of the messages but without any actual estimation. It takes a `hw_api/odometry` topic and republishes it to the system on correct topics (`estimation_manager/odom_main`, `estimation_manager/uav_state`, etc.). The `hw_api/odometry` topic is taken from the `mavros/local_position/odom` topic, which has ZOH on orientation and angular velocities. Other estimators (`gps_baro`, `rtk`, etc.) subscribe `hw_api/orientation` and `hw_api/angular_velocity`, which are correct.

**Why not just use `mavros/odometry/in` then?**

Unfortunately, it is not possible to just use `odometry/in` or `local_position/odom` topics as both have some kind of problems. So we need to combine these two topics into the `hw_api/odometry`, taking into account their specifics:

## Status of `odometry/in`

- ok orientation and angular velocities
- published even without valid position estimate
- not present in old PX4 FW (<1.14?)
- wrong frame of linear velocities (not sure what frame it is in but definitely not body)

## Status of `local_position/odom`

- zero-order interpolation of orientation and angular velocities (10 Hz -> 100 Hz)
- published only with valid position estimate (needs GNSS)
- present in old PX4 FW
- correct frame of linear velocities (body)

# Before this PR

The `hw_api/odometry` topic before this PR was republished from the `local_position/odom`.

# Proposed fix - this PR

Still use the `local_position/odom` as the base of the `hw_api/odometry` but take the orientation and angular velocity from `odometry/in`. This change should not change how all the other estimators work.
This PR needs to be implemented also in ROS2

# Testing

It is not possible to test this in simulation because these issues do not exist there. I will test this tomorrow (11.3.) in realworld flights to see if we can merge this. 