### PR TITLE
fix: high rate orientation in hw_api/odometry

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -191,6 +191,12 @@ private:
   std::atomic<bool> armed_     = false;
   std::atomic<bool> connected_ = false;
   std::mutex        mutex_status_;
+
+  geometry_msgs::msg::Quaternion orientation_;
+  std::mutex                mutex_orientation_;
+
+  geometry_msgs::msg::Vector3 angular_velocity_;
+  std::mutex             mutex_angular_velocity_;
 };
 
 //}
@@ -766,15 +772,24 @@ void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::msg::Odometry::ConstSha
 
   RCLCPP_INFO_ONCE(node_->get_logger(), "getting Mavros's local odometry");
 
-  auto odom = msg;
+  nav_msgs::msg::Odometry odom = *msg;
+
+  {
+    std::scoped_lock lock(mutex_orientation_);
+    odom.pose.pose.orientation = orientation_ ;
+  }
+  {
+    std::scoped_lock lock(mutex_angular_velocity_);
+    odom.twist.twist.angular = angular_velocity_ ;
+  }
 
   // | -------------------- publish position -------------------- |
 
   geometry_msgs::msg::PointStamped position;
 
-  position.header.stamp    = odom->header.stamp;
+  position.header.stamp    = msg->header.stamp;
   position.header.frame_id = _uav_name_ + "/" + _world_frame_name_;
-  position.point           = odom->pose.pose.position;
+  position.point           = msg->pose.pose.position;
 
   double lat, lon, correct_x, correct_y;
 
@@ -786,8 +801,8 @@ void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::msg::Odometry::ConstSha
       // therefore, we convert it back to WGS84 frame and then convert correctly using mrs_lib.
 
       // BEGIN PX4 CODE
-      const double x_rad = (double)odom->pose.pose.position.y / 6371000.0;
-      const double y_rad = (double)odom->pose.pose.position.x / 6371000.0;
+      const double x_rad = (double)msg->pose.pose.position.y / 6371000.0;
+      const double y_rad = (double)msg->pose.pose.position.x / 6371000.0;
       const double c = sqrt(x_rad * x_rad + y_rad * y_rad);
 
       if (fabs(c) > 0) {
@@ -828,9 +843,9 @@ void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::msg::Odometry::ConstSha
 
     geometry_msgs::msg::Vector3Stamped velocity;
 
-    velocity.header.stamp    = odom->header.stamp;
+    velocity.header.stamp    = msg->header.stamp;
     velocity.header.frame_id = _uav_name_ + "/" + _body_frame_name_;
-    velocity.vector          = odom->twist.twist.linear;
+    velocity.vector          = msg->twist.twist.linear;
 
     common_handlers_->publishers.publishVelocity(velocity);
   }
@@ -841,14 +856,14 @@ void MrsUavPx4Api::callbackOdometryLocal(const nav_msgs::msg::Odometry::ConstSha
 
     if (_capabilities_.produces_gnss and _ref_latlon_init) {
 
-      auto odom_new = *odom;
+      auto odom_new = odom;
       odom_new.pose.pose.position.x = correct_x;
       odom_new.pose.pose.position.y = correct_y;
       common_handlers_->publishers.publishOdometry(odom_new);
 
     } else {
 
-      common_handlers_->publishers.publishOdometry(*odom);
+      common_handlers_->publishers.publishOdometry(odom);
     }
   }
 }
@@ -867,6 +882,14 @@ void MrsUavPx4Api::callbackOdometryIn(const nav_msgs::msg::Odometry::ConstShared
 
   auto odom = msg;
 
+  {
+    std::scoped_lock lock(mutex_orientation_);
+    orientation_ = odom->pose.pose.orientation;
+  }
+  {
+    std::scoped_lock lock(mutex_angular_velocity_);
+    angular_velocity_ = odom->twist.twist.angular;
+  }
 
   // | ------------------- publish orientation ------------------ |
 


### PR DESCRIPTION
All `mrs_uav_managers` tests pass:
```

100% tests passed, 0 tests failed out of 49

Label Time Summary:
clang_format    =   0.66 sec*proc (1 test)
launch_test     = 1203.96 sec*proc (47 tests)
linter          =   0.99 sec*proc (2 tests)
xmllint         =   0.33 sec*proc (1 test)

Total Test time (real) = 1205.01 sec
Finished <<< mrs_uav_managers [20min 5s]
```