### PR TITLE
Feat/rc signal

### DIFF
--- a/config/px4_api.yaml
+++ b/config/px4_api.yaml
@@ -25,6 +25,7 @@ plugin:
     magnetometer_heading: true
     magnetic_field:       true
     rc_channels:          true
+    rc_rssi:              true
     battery_state:        true
     position:             true
     orientation:          true

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -68,7 +68,7 @@ namespace mrs_uav_px4_api
 class MrsUavPx4Api : public mrs_uav_hw_api::MrsUavHwApi {
 
 public:
-  ~MrsUavPx4Api() {};
+  ~MrsUavPx4Api(){};
 
   void initialize(const rclcpp::Node::SharedPtr &node, std::shared_ptr<mrs_uav_hw_api::CommonHandlers_t> common_handlers);
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -68,7 +68,7 @@ namespace mrs_uav_px4_api
 class MrsUavPx4Api : public mrs_uav_hw_api::MrsUavHwApi {
 
 public:
-  ~MrsUavPx4Api(){};
+  ~MrsUavPx4Api() {};
 
   void initialize(const rclcpp::Node::SharedPtr &node, std::shared_ptr<mrs_uav_hw_api::CommonHandlers_t> common_handlers);
 
@@ -308,6 +308,7 @@ void MrsUavPx4Api::initialize(const rclcpp::Node::SharedPtr &node, std::shared_p
   local_param_loader.loadParam("outputs/magnetometer_heading", (bool &)_capabilities_.produces_magnetometer_heading);
   local_param_loader.loadParam("outputs/magnetic_field", (bool &)_capabilities_.produces_magnetic_field);
   local_param_loader.loadParam("outputs/rc_channels", (bool &)_capabilities_.produces_rc_channels);
+  local_param_loader.loadParam("outputs/rc_rssi", (bool &)_capabilities_.produces_rc_rssi);
   local_param_loader.loadParam("outputs/battery_state", (bool &)_capabilities_.produces_battery_state);
   local_param_loader.loadParam("outputs/position", (bool &)_capabilities_.produces_position);
   local_param_loader.loadParam("outputs/orientation", (bool &)_capabilities_.produces_orientation);
@@ -1152,9 +1153,12 @@ void MrsUavPx4Api::callbackRC(const mavros_msgs::msg::RCIn::ConstSharedPtr msg) 
     }
 
     common_handlers_->publishers.publishRcChannels(rc_out);
+  }
 
-    std_msgs::msg::UInt8 rssi_out;
-    rssi_out.data = msg->rssi;
+  if (_capabilities_.produces_rc_rssi) {
+    mrs_msgs::msg::HwApiRcRssi rssi_out;
+    rssi_out.stamp = msg->header.stamp;
+    rssi_out.rssi  = msg->rssi;
     common_handlers_->publishers.publishRcRssi(rssi_out);
   }
 }

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -23,6 +23,7 @@
 #include <mrs_lib/errorgraph/error_publisher.h>
 
 #include <std_msgs/msg/float64.hpp>
+#include <std_msgs/msg/u_int8.hpp>
 
 #include <geometry_msgs/msg/quaternion_stamped.hpp>
 
@@ -1151,6 +1152,10 @@ void MrsUavPx4Api::callbackRC(const mavros_msgs::msg::RCIn::ConstSharedPtr msg) 
     }
 
     common_handlers_->publishers.publishRcChannels(rc_out);
+
+    std_msgs::msg::UInt8 rssi_out;
+    rssi_out.data = msg->rssi;
+    common_handlers_->publishers.publishRcRssi(rssi_out);
   }
 }
 


### PR DESCRIPTION
## Summary
- **What changed**:
    - Publishing RC RSSI
    - Modified px4 config file to specify it produces rc_rssi 
- **Why**:
    - Currently, `HwApi` only shares the **RC Channels**,  and not using the  **RC Received Signal Strength Indicator (RSSI)**  that PX4 already shares in the `rc` [message](https://github.com/mavlink/mavros/blob/master/mavros_msgs/msg/RCIn.msg#L4)

## Impact
- **Breaking changes**: 
     Depends on:
     `mrs_msgs`:  https://github.com/ctu-mrs/mrs_msgs/pull/23
     `hw_api`: https://github.com/ctu-mrs/mrs_uav_hw_api/pull/7

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [x] Tested in simulation
    * [x] Tested on real HW