### PR TITLE
fix: fixed the global heading so it's transformed from NED to ENU

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -17,6 +17,7 @@
 #include <mrs_lib/subscribe_handler.h>
 #include <mrs_lib/service_client_handler.h>
 #include <mrs_lib/gps_conversions.h>
+#include <mrs_lib/geometry/cyclic.h>
 
 #include <std_msgs/Float64.h>
 
@@ -925,10 +926,15 @@ void MrsUavPx4Api::callbackMagnetometer(const std_msgs::Float64::ConstPtr msg) {
 
   if (_capabilities_.produces_magnetometer_heading) {
 
+    // Converting the value from MAVROS msg in NED degrees into ENU radians for consistency with other values.
+    // The Mavros heading angle is given in degrees from 0.0 to 359.99 degrees in the North-East-Down coordinate frame.
+    const auto global_heading_ned = mrs_lib::geometry::degrees::convert<mrs_lib::geometry::sradians>(msg->data).value();
+    const auto global_heading_enu = mrs_lib::geometry::headingNEDtoENU(global_heading_ned);
+
     mrs_msgs::Float64Stamped mag_out;
     mag_out.header.stamp    = ros::Time::now();
     mag_out.header.frame_id = _uav_name_ + "/" + _world_frame_name_;
-    mag_out.value           = msg->data;
+    mag_out.value           = global_heading_enu;
 
     common_handlers_->publishers.publishMagnetometerHeading(mag_out);
   }


### PR DESCRIPTION
title is self-explanatory, see #13 for the ROS2 version of this fix